### PR TITLE
Add exception to capture no response from Notify

### DIFF
--- a/main.py
+++ b/main.py
@@ -178,7 +178,6 @@ def send_email(request: Request) -> Tuple[str, int]:
             status_code=status_code,
         )
         return message, status_code
-
     except RequestException as error:
         notify_error = error.response.json()["errors"][0]
         status_code = error.response.status_code

--- a/main.py
+++ b/main.py
@@ -181,7 +181,14 @@ def send_email(request: Request) -> Tuple[str, int]:
             )
             return message, error.response.status_code
         except AttributeError:
-            return "no response", 444
+            message = "no response"
+            status_code = 444
+            log_error(
+                message,
+                **log_context,
+                status_code=status_code,
+            )
+            return message, status_code
 
     if response.status_code == 204:
         return "no content", 204

--- a/main.py
+++ b/main.py
@@ -169,16 +169,19 @@ def send_email(request: Request) -> Tuple[str, int]:
         response.raise_for_status()
         log_info("notify email requested", **log_context)
     except RequestException as error:
-        notify_error = error.response.json()["errors"][0]
-        status_code = error.response.status_code
-        message = "notify request failed"
-        log_error(
-            message,
-            **log_context,
-            notify_error=notify_error,
-            status_code=status_code,
-        )
-        return message, error.response.status_code
+        try:
+            notify_error = error.response.json()["errors"][0]
+            status_code = error.response.status_code
+            message = "notify request failed"
+            log_error(
+                message,
+                **log_context,
+                notify_error=notify_error,
+                status_code=status_code,
+            )
+            return message, error.response.status_code
+        except AttributeError:
+            return "no response", 444
 
     if response.status_code == 204:
         return "no content", 204

--- a/main.py
+++ b/main.py
@@ -171,15 +171,6 @@ def send_email(request: Request) -> Tuple[str, int]:
     except RequestException as error:
         try:
             notify_error = error.response.json()["errors"][0]
-            status_code = error.response.status_code
-            message = "notify request failed"
-            log_error(
-                message,
-                **log_context,
-                notify_error=notify_error,
-                status_code=status_code,
-            )
-            return message, error.response.status_code
         except AttributeError:
             message = "no response"
             status_code = 444
@@ -189,6 +180,16 @@ def send_email(request: Request) -> Tuple[str, int]:
                 status_code=status_code,
             )
             return message, status_code
+
+        status_code = error.response.status_code
+        message = "notify request failed"
+        log_error(
+            message,
+            **log_context,
+            notify_error=notify_error,
+            status_code=status_code,
+        )
+        return message, error.response.status_code
 
     if response.status_code == 204:
         return "no content", 204

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import jwt
 from flask import Request
 from google.cloud import secretmanager
 from requests import Session
+from requests.exceptions import ConnectionError as RequestConnectionError
 from requests.exceptions import RequestException
 
 from exceptions import InvalidNotifyKeyError, InvalidRequestError
@@ -168,19 +169,18 @@ def send_email(request: Request) -> Tuple[str, int]:
         )
         response.raise_for_status()
         log_info("notify email requested", **log_context)
-    except RequestException as error:
-        try:
-            notify_error = error.response.json()["errors"][0]
-        except AttributeError:
-            message = "no response"
-            status_code = 444
-            log_error(
-                message,
-                **log_context,
-                status_code=status_code,
-            )
-            return message, status_code
+    except RequestConnectionError:
+        message = "connection error"
+        status_code = 504
+        log_error(
+            message,
+            **log_context,
+            status_code=status_code,
+        )
+        return message, status_code
 
+    except RequestException as error:
+        notify_error = error.response.json()["errors"][0]
         status_code = error.response.status_code
         message = "notify request failed"
         log_error(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,6 +55,13 @@ def test_notify_response_error_returns_correctly(mock_request):
 
 
 @responses.activate
+def test_notify_response_error_connection_reset_error(mock_request):
+    responses.add(responses.GET, url, body=Exception(ConnectionResetError))
+    response = send_email(mock_request)
+    assert response == ("no response", 444)
+
+
+@responses.activate
 def test_notify_response_no_content_204(mock_request):
     responses.add(responses.POST, url, json={}, status=204)
     response = send_email(mock_request)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,7 +57,7 @@ def test_notify_response_error_returns_correctly(mock_request):
 
 @responses.activate
 def test_notify_response_connection_error(mock_request):
-    responses.add(responses.GET, url, body=RequestConnectionError)
+    responses.add(responses.POST, url, body=RequestConnectionError())
     response = send_email(mock_request)
     assert response == ("connection error", 504)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,7 @@ from google.cloud.secretmanager_v1.types import (
     AccessSecretVersionResponse,
     SecretPayload,
 )
+from requests.exceptions import ConnectionError as RequestConnectionError
 
 import main
 from exceptions import InvalidNotifyKeyError
@@ -55,10 +56,10 @@ def test_notify_response_error_returns_correctly(mock_request):
 
 
 @responses.activate
-def test_notify_response_error_connection_reset_error(mock_request):
-    responses.add(responses.GET, url, body=Exception(ConnectionResetError))
+def test_notify_response_connection_error(mock_request):
+    responses.add(responses.GET, url, body=RequestConnectionError)
     response = send_email(mock_request)
-    assert response == ("no response", 444)
+    assert response == ("connection error", 504)
 
 
 @responses.activate


### PR DESCRIPTION
### What is the context of this PR?

During testing we were seeing ConnectionResetError leading to 30 second timeouts, this doesn't fix that issue, but captures a no response from notify and addresses the timeouts

N.B  'if not error.response' when a 403 is evaluated as true and is the reason I when with AttributeError rather than an 'if' on the error response

### How to review
Difficult to test without load, so it's more a case of looking at the code and test and making sure it looks ok

### Checklist

\*[ ] Tests updated
