### PR TITLE
Add pause/resume Cloud Task queue Yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,24 +57,3 @@ Once authenticated and the notify_api_key set, run `make deploy_function`.
 For development purposes it is possible to delete the function in GCP from a local machine using the `gcloud` command. First login using `gcloud auth login`, then set the application default credentials using `gcloud auth application-default login`. Be sure to make the current gcloud project id the one you wish to deploy to `gcloud config set project <your-project-id>`
 
 Once authenticated, run `make delete_function`.
-
-## Pause Cloud Task queue
-
-A cloud task queue can be paused by using the `pause_cloud_task_queue.yaml` task. This can be done via Concourse using the following command:
-
-```sh
-PROJECT_ID=<project_id> \
-QUEUE_NAME=<queue_name> \
-fly -t <target-concourse> execute \
-  --config ci/pause_cloud_task_queue.yaml
-```
-
-## Resume Cloud Task queue
-
-A cloud task queue can be resumed by using the `resume_cloud_task_queue.yaml` task. This can be done via Concourse using the following command:
-
-```sh
-PROJECT_ID=<project_id> \
-QUEUE_NAME=<queue_name> \
-fly -t <target-concourse> execute \
-  --config ci/resume_cloud_task_queue.yaml

--- a/README.md
+++ b/README.md
@@ -52,9 +52,29 @@ You can also use an environment variable if you do not have access to Secret Man
 Once authenticated and the notify_api_key set, run `make deploy_function`.
 
 
-
 ## Deleting from local machine
 
 For development purposes it is possible to delete the function in GCP from a local machine using the `gcloud` command. First login using `gcloud auth login`, then set the application default credentials using `gcloud auth application-default login`. Be sure to make the current gcloud project id the one you wish to deploy to `gcloud config set project <your-project-id>`
 
 Once authenticated, run `make delete_function`.
+
+## Pause Cloud Task queue
+
+A cloud task queue can be paused by using the `pause_cloud_task_queue.yaml` task. This can be done via Concourse using the following command:
+
+```sh
+PROJECT_ID=<project_id> \
+QUEUE_NAME=<queue_name> \
+fly -t <target-concourse> execute \
+  --config ci/pause_cloud_task_queue.yaml
+```
+
+## Resume Cloud Task queue
+
+A cloud task queue can be resumed by using the `resume_cloud_task_queue.yaml` task. This can be done via Concourse using the following command:
+
+```sh
+PROJECT_ID=<project_id> \
+QUEUE_NAME=<queue_name> \
+fly -t <target-concourse> execute \
+  --config ci/resume_cloud_task_queue.yaml

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,21 @@
+## Pause Cloud Task queue
+
+A cloud task queue can be paused by using the `pause_cloud_task_queue.yaml` task. This can be done via Concourse using the following command:
+
+```sh
+PROJECT_ID=<project_id> \
+QUEUE_NAME=<queue_name> \
+fly -t <target-concourse> execute \
+  --config ci/pause_cloud_task_queue.yaml
+```
+
+## Resume Cloud Task queue
+
+A cloud task queue can be resumed by using the `resume_cloud_task_queue.yaml` task. This can be done via Concourse using the following command:
+
+```sh
+PROJECT_ID=<project_id> \
+QUEUE_NAME=<queue_name> \
+fly -t <target-concourse> execute \
+  --config ci/resume_cloud_task_queue.yaml
+```

--- a/ci/pause_cloud_task_queue.yaml
+++ b/ci/pause_cloud_task_queue.yaml
@@ -1,0 +1,23 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/google.com/cloudsdktool/cloud-sdk
+    tag: alpine
+params:
+  SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+  PROJECT_ID:
+  QUEUE_NAME:
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud config set project "${PROJECT_ID}"
+      gcloud tasks queues pause "${QUEUE_NAME}"

--- a/ci/resume_cloud_task_queue.yaml
+++ b/ci/resume_cloud_task_queue.yaml
@@ -1,0 +1,23 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/google.com/cloudsdktool/cloud-sdk
+    tag: alpine
+params:
+  SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+  PROJECT_ID:
+  QUEUE_NAME:
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud config set project "${PROJECT_ID}"
+      gcloud tasks queues resume "${QUEUE_NAME}"


### PR DESCRIPTION
### What is the context of this PR?
This PR introduces yaml tasks to allow the pausing/resuming of a cloud task queue in GCP

### How to review 
In a test GCP environment with a cloud task queue (eq-submission-confirmation) check the scripts pause/resume the queue

### Checklist

\*[ ] Tests updated
