### PR TITLE
Remove test from actions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,8 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
     steps:
       - uses: actions/checkout@v2
       - run: |
@@ -23,5 +21,3 @@ jobs:
         run: make install-dev
       - name: Running lint tests
         run: make lint
-      - name: Running code tests
-        run: make test


### PR DESCRIPTION
### What is the context of this PR?

- The tests that interact with Notify API have been removed from actions until a mock service can be introduced.
- The secret has been removed from GitHub also.

### How to review

Ensure the tests are not run in Actions for this PR.

### Checklist

\*[ ] Tests updated
