### PR TITLE
Update deprecated pipenv lock command

### DIFF
--- a/ci/deploy_function.yaml
+++ b/ci/deploy_function.yaml
@@ -25,5 +25,5 @@ run:
 
       cd eq-submission-confirmation-consumer
       pip3 install pipenv
-      pipenv lock --keep-outdated -r > requirements.txt
+      pipenv requirements > requirements.txt
       ./scripts/deploy_function.sh


### PR DESCRIPTION
### What is the context of this PR?

This updates deprecated `pipenv lock -r` command from `deploy` yaml file. `--keep outdated` option had to be removed as it is not supported for the new command. 

### How to review

Check my existing staging pipeline where I deployed this branch of the consumer (and tested deploy/destroy few times using this branch). Deploy your own env to test.

### Checklist

\*[ ] Tests updated
