### PR TITLE
Migrate CI tasks to use registry-image

### DIFF
--- a/ci/delete_function.yaml
+++ b/ci/delete_function.yaml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/google.com/cloudsdktool/cloud-sdk
     tag: slim

--- a/ci/deploy_credentials.yaml
+++ b/ci/deploy_credentials.yaml
@@ -1,6 +1,6 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/google.com/cloudsdktool/cloud-sdk
     tag: alpine

--- a/ci/deploy_function.yaml
+++ b/ci/deploy_function.yaml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ((image_registry))/eq-submission-confirmation-consumer-deploy-image
     tag: ((deploy_image_version))

--- a/ci/destroy_credentials.yaml
+++ b/ci/destroy_credentials.yaml
@@ -1,6 +1,6 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/google.com/cloudsdktool/cloud-sdk
     tag: alpine

--- a/ci/pause_cloud_task_queue.yaml
+++ b/ci/pause_cloud_task_queue.yaml
@@ -1,6 +1,6 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/google.com/cloudsdktool/cloud-sdk
     tag: alpine

--- a/ci/resume_cloud_task_queue.yaml
+++ b/ci/resume_cloud_task_queue.yaml
@@ -1,6 +1,6 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/google.com/cloudsdktool/cloud-sdk
     tag: alpine


### PR DESCRIPTION
What is the context of this PR?
Migrates our CI tasks in Runner to use registry-image rather than docker-image

How to review
Ensure the pipelines that reference these tasks are still working.

### Checklist
\*[ ] Tests updated
