### PR TITLE
Migrate to docker image repo

### DIFF
--- a/ci/deploy_function.yaml
+++ b/ci/deploy_function.yaml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ((image_registry))/eq-submission-confirmation-consumer-deploy-image
+    repository: ((image_registry))/eq-python-deploy-image
     tag: ((deploy_image_version))
 inputs:
   - name: eq-submission-confirmation-consumer


### PR DESCRIPTION
### What is the context of this PR?
We're migrating eQ pipeline resources to point at our centralised custom Docker file repo: https://github.com/ONSdigital/eq-runner-docker-images

### How to review
Push up each of the Dockerfiles from above, and set your dev pipeline `image_registry` var to point to your dockerfile registry. The pipeline job should still pass.

### Checklist
\*[ ] Tests updated
