### PR TITLE
Update runtime to Python 3.12 and update service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ For the cloud function to work it needs a valid Notify API key, this can be prov
 
 Firstly check that Secret Manager in GCP is enabled, if not enable it. You can add the `notify_api_key` manually in the UI or use the gcloud commands below. If doing it manually, go to Secret Manager in GCP and click `Create Secret`, enter the name as `notify_api_key` and your secret value, a region can also be set if required.
 
-Once the secret has been created, click on the name `notify_api_key` and expand the info panel on the right if not already showing. In this menu click add member and fill out the form, member should be `<project_id>@appspot.gserviceaccount.com` and role should be `Secret Manager Secret Accessor`
+Once the secret has been created, click on the name `notify_api_key` and expand the info panel on the right if not already showing. In this menu click add member and fill out the form, member should be `<project_id>-compute@developer.gserviceaccount.com` and role should be `Secret Manager Secret Accessor`
 
 If using gcloud commands run the following
 
 ```
 gcloud secrets create notify_api_key --data-file=<data_file> --project=<project_id> --replication-policy=<replication-policy> --locations=<locations>
 
-gcloud secrets add-iam-policy-binding `notify_api_key` --role roles/secretmanager.secretAccessor --member serviceAccount:<project_id>@appspot.gserviceaccount.com
+gcloud secrets add-iam-policy-binding `notify_api_key` --role roles/secretmanager.secretAccessor --member serviceAccount:<project_id>-compute@developer.gserviceaccount.com
 ```
 
 N.B. replication-policy can be `automatic` or `user-managed`. If automatic neither `replication-policy` or `location` needs to be included in the command, if user-managed `replication-policy` and `location` must be provided

--- a/ci/deploy_credentials.sh
+++ b/ci/deploy_credentials.sh
@@ -12,10 +12,11 @@ if [[ -z "$NOTIFY_API_KEY_FILE" ]]; then
 fi
 
 KEY_NAME="notify_api_key"
+PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
 
 gcloud secrets create "$KEY_NAME" --replication-policy="automatic" --project="$PROJECT_ID" || true
 gcloud secrets versions add "$KEY_NAME" --data-file="$NOTIFY_API_KEY_FILE" --project="$PROJECT_ID"
 
-# Give the default App Engine service account access to this secret
+# Give the default compute service account access to this secret
 gcloud secrets add-iam-policy-binding "$KEY_NAME" --role roles/secretmanager.secretAccessor \
-  --member "serviceAccount:$PROJECT_ID@appspot.gserviceaccount.com" --project="$PROJECT_ID"
+  --member "serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com" --project="$PROJECT_ID"

--- a/scripts/deploy_function.sh
+++ b/scripts/deploy_function.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 gcloud functions deploy eq-submission-confirmation-consumer \
-    --entry-point send_email --runtime python311 --trigger-http \
+    --entry-point send_email --runtime python312 --trigger-http \
     --region=europe-west2 -q


### PR DESCRIPTION
### What is the context of this PR?
Now that we've moved to Python 3.12, we need to adjust the runtime for this cloud function, along with the service account name to allow the compute service account to access the `notify_api_key`

### How to review
Describe the steps required to test the changes (include screenshots if appropriate).
Run with the pipeline changes in this PR: https://github.com/ONSdigital/eq-pipelines/pull/637

### Checklist
\*[ ] Tests updated
