### PR TITLE
Add Poetry export plugin & pin version

### DIFF
--- a/ci/deploy_function.yaml
+++ b/ci/deploy_function.yaml
@@ -24,6 +24,6 @@ run:
       gcloud config set project "${PROJECT_ID}"
 
       cd eq-submission-confirmation-consumer
-      pip3 install poetry
+      pip3 install poetry poetry-plugin-export
       poetry export --without-hashes --format=requirements.txt > requirements.txt
       ./scripts/deploy_function.sh

--- a/ci/deploy_function.yaml
+++ b/ci/deploy_function.yaml
@@ -24,6 +24,6 @@ run:
       gcloud config set project "${PROJECT_ID}"
 
       cd eq-submission-confirmation-consumer
-      pip3 install poetry poetry-plugin-export
+      pip3 install poetry==2.0.0 poetry-plugin-export
       poetry export --without-hashes --format=requirements.txt > requirements.txt
       ./scripts/deploy_function.sh


### PR DESCRIPTION
### What is the context of this PR?
The export plugin for Poetry is no longer installed by default since the CI script installs the 2.0 version. This updates the Poetry install step in deploy task to add the export plugin and pins the version.

### How to review
Deploy staging using this branch in the pipeline's GitHub resources section.

### Checklist
\*[ ] Tests updated
