### PR TITLE
Set secret command replication policy flag to user-managed

### DIFF
--- a/ci/deploy_credentials.sh
+++ b/ci/deploy_credentials.sh
@@ -14,7 +14,7 @@ fi
 KEY_NAME="notify_api_key"
 PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
 
-gcloud secrets create "$KEY_NAME" --replication-policy="user-managed" --locations=europe-west2 --project="$PROJECT_ID" || true
+gcloud secrets create "$KEY_NAME" --replication-policy="user-managed" --locations="europe-west2" --project="$PROJECT_ID" || true
 gcloud secrets versions add "$KEY_NAME" --data-file="$NOTIFY_API_KEY_FILE" --project="$PROJECT_ID"
 
 # Give the default compute service account access to this secret

--- a/ci/deploy_credentials.sh
+++ b/ci/deploy_credentials.sh
@@ -14,7 +14,7 @@ fi
 KEY_NAME="notify_api_key"
 PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
 
-gcloud secrets create "$KEY_NAME" --replication-policy="automatic" --project="$PROJECT_ID" || true
+gcloud secrets create "$KEY_NAME" --replication-policy="user-managed" --project="$PROJECT_ID" || true
 gcloud secrets versions add "$KEY_NAME" --data-file="$NOTIFY_API_KEY_FILE" --project="$PROJECT_ID"
 
 # Give the default compute service account access to this secret

--- a/ci/deploy_credentials.sh
+++ b/ci/deploy_credentials.sh
@@ -14,7 +14,7 @@ fi
 KEY_NAME="notify_api_key"
 PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
 
-gcloud secrets create "$KEY_NAME" --replication-policy="user-managed" --project="$PROJECT_ID" || true
+gcloud secrets create "$KEY_NAME" --replication-policy="user-managed" --locations=europe-west2 --project="$PROJECT_ID" || true
 gcloud secrets versions add "$KEY_NAME" --data-file="$NOTIFY_API_KEY_FILE" --project="$PROJECT_ID"
 
 # Give the default compute service account access to this secret


### PR DESCRIPTION
### What is the context of this PR?
Our staging pipeline has fallen over as the deploy infrastructure task has failed. This was caused by a new policy that has been added to stop the creation of secrets with an automatic replication policy and we now need to switch the a user-managed replication with a region set in locations allowed by the policy.

This PR amends the gcloud command for secret creation to ensure the replication policy is set to user-managed and assigned an appropriate location: `europe-west2`.

### How to review
Create a Staging pipeline pointing to this branch, use alongside [eq-terraform-gcp feature-prepop pr](https://github.com/ONSdigital/eq-terraform-gcp/pull/122) & [eq-submission-confirmation-consumer pr](https://github.com/ONSdigital/eq-submission-confirmation-consumer/pull/57)
