### PR TITLE
Bump pyasn1 from 0.6.1 to 0.6.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -956,14 +956,14 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.2"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf"},
+    {file = "pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"},
 ]
 
 [[package]]


### PR DESCRIPTION
### What is the context of this PR?
Update `pyasn1`to `v0.6.2`
https://github.com/ONSdigital/eq-submission-confirmation-consumer/security/dependabot/47

### How to review
Check `pyasn1` has been bumped up - `poetry show pyasn1`  

### Checklist
\*[ ] Tests updated
